### PR TITLE
Fixes the crash caused by commit 74c0622

### DIFF
--- a/maps/SilphCo7F.blk
+++ b/maps/SilphCo7F.blk
@@ -1,1 +1,1 @@
-@Aa`AAB}|=$>D/d""#qFDGDZcgBD/@cgBF4F@aaD44FF6FDD66FF7FD	D77FFcgBDHIIIJF/FHIIIIIIIJWIIJ
+@Aa`AAB}==$>D/d""#qFDGDZcgBD/@cgBF4F@aaD44FF6FDD66FF7FD	D77FFcgBDHIIIJF/FHIIIIIIIJWIIJ


### PR DESCRIPTION
Replaced the elevator block in SilphCo7F.blk.