### PR TITLE
Candy jar rework

### DIFF
--- a/data/items/key_items.asm
+++ b/data/items/key_items.asm
@@ -75,7 +75,7 @@ KeyItemFlags:
 	dbit TRUE  ; POKE_FLUTE
 	dbit TRUE  ; LIFT_KEY
 	dbit FALSE ; EXP_ALL
-	dbit FALSE  ; was TRUE for OLD_ROD, now CANDY_SACK
+	dbit TRUE  ; was TRUE for OLD_ROD, now CANDY_JAR
 	dbit FALSE  ; was GOOD_ROD & TRUE, now BOTTLE_CAP
 	dbit TRUE  ; SUPER_ROD
 	dbit FALSE ; PP_UP

--- a/data/text/text_2.asm
+++ b/data/text/text_2.asm
@@ -1838,6 +1838,6 @@ _MysteryBoxCloseText::
 _CandyJarCount::
 	text "MELTAN CANDY:"
 	line "@"
-	text_bcd wCandyJarCount, 2 | LEADING_ZEROES | LEFT_ALIGN
+	text_decimal wCandyJarCount, 1, 2
 	text "0"
 	prompt

--- a/data/text/text_2.asm
+++ b/data/text/text_2.asm
@@ -1834,3 +1834,10 @@ _MysteryBoxCloseText::
 	text "<PLAYER> closed"
 	line "the BOX!"
 	prompt
+
+_CandyJarCount::
+	text "MELTAN CANDY:"
+	line "@"
+	text_bcd wCandyJarCount, 2 | LEADING_ZEROES | LEFT_ALIGN
+	text "0"
+	prompt

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -839,6 +839,26 @@ FaintEnemyPokemon:
 	call PrintText
 	call PrintEmptyString
 	call SaveScreenTilesToBuffer1
+	
+	; Meltan Candy functionality.
+	; The way this is done looks like it conflates 8- and 16-bit integers, but it never goes above 256, so it'll be fine.
+	ld a, [wEnemyMonSpecies] ; Load species.
+	cp $E7 ; Is it Meltan?
+	jr nz, .skip ; Continue as normal if not.
+	
+	; For engine\overworld\clear_variables.asm
+	; Needed so the Mystery Box effect isn't cleared upon leaving battle.
+	ld a, $01
+	ld [wDontSwitchOffMysteryBoxYet], a
+	
+	ld a, [wCandyJarCount]
+	inc a
+	ld [wCandyJarCount], a
+	
+	ld hl, MeltanIncrement ; Load text to show it's going up.
+	call PrintText ; Yep text.
+	call PrintEmptyString ; vs text likes this.
+.skip
 	xor a
 	ld [wBattleResult], a
 	ld a, [wCurMap]
@@ -7172,4 +7192,9 @@ LoadMonBackPic:
 StupidBattleTentFix:
 	text "Oops! Better"
 	line "luck next time!"
+	prompt
+
+MeltanIncrement:
+	text "<PLAYER> found"
+	line "10 MELTAN CANDY!"
 	prompt

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -846,14 +846,15 @@ FaintEnemyPokemon:
 	cp $E7 ; Is it Meltan?
 	jr nz, .skip ; Continue as normal if not.
 	
+	; Increment the Candy Jar count.
+	ld a, [wCandyJarCount]
+	inc a
+	ld [wCandyJarCount], a
+	
 	; For engine\overworld\clear_variables.asm
 	; Needed so the Mystery Box effect isn't cleared upon leaving battle.
 	ld a, $01
 	ld [wDontSwitchOffMysteryBoxYet], a
-	
-	ld a, [wCandyJarCount]
-	inc a
-	ld [wCandyJarCount], a
 	
 	ld hl, MeltanIncrement ; Load text to show it's going up.
 	call PrintText ; Yep text.

--- a/engine/debug/debug_party.asm
+++ b/engine/debug/debug_party.asm
@@ -44,6 +44,10 @@ IF DEF(_DEBUG)
 	ld a, 1
 	ld [wPlayerSex], a
 	
+	; Test Candy Jar Evolution
+	ld a, 39
+	ld [wCandyJarCount], a
+	
 	; Get all badges except Earth Badge.
 	ld a, ~(1 << BIT_EARTHBADGE)
 	ld [wObtainedBadges], a

--- a/engine/debug/debug_party.asm
+++ b/engine/debug/debug_party.asm
@@ -22,12 +22,11 @@ SetIshiharaTeam:
 
 IshiharaTeam:
 	db EXEGGUTOR_A, 90
-	db PURAKKUSU, 90
+	db MELTAN, 90
 	db TRAMPEL, 90
 IF DEF(_DEBUG)
 	db TAUROS_PB, 90
 	db SNORLAX, 50
-	db TANGROWTH, 50
 ENDC
 	db -1 ; end
 
@@ -162,6 +161,7 @@ DebugSetPokedexEntries:
 
 DebugItemsList:
 	db MYSTERY_BOX, 1
+	db CANDY_JAR, 1
 	db BICYCLE, 1
 	db FULL_RESTORE, 99
 	db MAX_REPEL, 99

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -144,7 +144,7 @@ ItemUseCandyJar:
 	and a
 	jp nz, ItemUseNotTime
 	
-	ld [wCandyJarCount], a ; Get the Candy count
+	ld a, [wCandyJarCount] ; Get the Candy count
 	cp 40 ; Is it 40? (represented as 400)
 	jr z, .Evolve ; If yes, jump to Evo Stone Script
 	ld hl, CandyJarCount ; Otherwise, load the Candy total...

--- a/engine/overworld/clear_variables.asm
+++ b/engine/overworld/clear_variables.asm
@@ -10,11 +10,20 @@ ClearVariablesOnEnterMap::
 	ldh [hJoyReleased], a
 	ldh [hJoyHeld], a
 	ld [wActionResultOrTookBattleTurn], a
-	ld [wMysteryBoxActive], a
 	ld hl, wCardKeyDoorY
 	ld [hli], a
 	ld [hl], a
 	ld hl, wWhichTrade
 	ld bc, wStandingOnWarpPadOrHole - wWhichTrade
 	call FillMemory
+	
+	; The Mystery Box for Meltan gets switched off when leaving every map, but SPECIFICALLY not after a battle.
+	; Because leaving battle is map re-entry, this exception is included.
+	ld a, [wDontSwitchOffMysteryBoxYet] ; Load WRAM bit.
+	and a ; Did a battle just happen?
+	jr nz, .skip ; Yes? Off you go then.
+	ld a, $0 ; No? Let's zero both of these out then.
+	ld [wMysteryBoxActive], a ; This is now deactivated.
+	ld [wDontSwitchOffMysteryBoxYet], a ; To be activated when a Meltan is defeated later.
+.skip
 	ret

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2131,7 +2131,6 @@ wObtainedHiddenCoinsFlags:: flag_array 16
 ; $01 = biking
 ; $02 = surfing
 wWalkBikeSurfState:: db
-
 	ds 10
 
 wTownVisitedFlag:: flag_array NUM_CITY_MAPS
@@ -2144,7 +2143,23 @@ wFossilItem:: db
 ; mon that will result from the item
 wFossilMon:: db
 
-	ds 2
+; Meltan WRAM entries.
+; Meltan uses a 3 unique variables for its item functionality.
+
+; This is for the Melmetal Evolution Item. 
+; If it reaches 40 (represented as 400), the player can evolve Meltan.
+; Once used, the count will reset.
+wCandyJarCount:: db
+
+; Used for Meltan implementation. Replaced unused Card Key function.
+; When byte is $01, Meltan has a chance to replace a Pokemon that appears.
+	; $00 - Not Active
+	; $01 - Active
+wMysteryBoxActive:: db
+
+; ClearVariablesOnEnterMap does everything I want, except when leaving battle, so this switches off that specific aspect.
+; This is achieved through some jank in engine\core.asm and engine\overworld\clear_variables.asm.
+wDontSwitchOffMysteryBoxYet:: db
 
 ; trainer classes start at OPP_ID_OFFSET
 wEnemyMonOrTrainerClass:: db
@@ -2152,9 +2167,7 @@ wEnemyMonOrTrainerClass:: db
 wPlayerJumpingYScreenCoordsIndex:: db
 
 wRivalStarter:: db
-
-	ds 1
-
+ds 1
 wPlayerStarter:: db
 
 ; sprite index of the boulder the player is trying to push
@@ -2176,12 +2189,6 @@ wDungeonWarpDestinationMap:: db
 
 ; which dungeon warp within the source map was used
 wWhichDungeonWarp:: db
-
-; Used for Meltan implementation. Replaced unused Card Key function.
-; When byte is $01, Meltan has a chance to replace a Pokemon that appears.
-	; $00 - Not Active
-	; $01 - Active
-wMysteryBoxActive:: db
 
 	ds 8
 


### PR DESCRIPTION
This adds the Candy Jar's new functionality where you get candies and can evolve Melmetal.
- Candy Jar is now a Key Item
- New variable where you increment the amount of dead Meltans in the form of Meltan Candy, up to 40. Currently, if you KO more than 40, it fucks up for some reason, but I'll fix that another time.
- Fixes a few bugs with the last commit.

To quote one commit:
> If you defeat a Meltan, `wCandyJarCount` increments by 1, capping at 40. This is represented in-game as 10, going up to 400, simply by adding a 0 at the end. This, in effect, replicates the Meltan quest from Pokemon Go.
> Once 40/400 is reached, the Candy Jar will become an evolution stone, evolving Meltan. Instead of consuming the Jar, the Candies inside are zeroed out.