### PR TITLE
Bug Fixes

### DIFF
--- a/data/tilesets/water_tilesets.asm
+++ b/data/tilesets/water_tilesets.asm
@@ -12,3 +12,8 @@ WaterTilesets:
 	db CITRINE
 	db CELESTE
 	db -1 ; end
+	
+NonShoreTilesets:
+	db GYM
+	db SHIP_PORT
+	db -1 ; end

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -174,6 +174,7 @@ GainExperience:
 	farcall CalcLevelFromExperience
 	pop hl
 	ld a, [hl] ; current level
+	ld [wTempLevel], a
 	cp d
 	jp z, .nextMon ; if level didn't change, go to next mon
 	ld a, [wCurEnemyLVL]
@@ -269,7 +270,20 @@ GainExperience:
 	ld [wMonDataLocation], a
 	ld a, [wd0b5]
 	ld [wd11e], a
+	ld a, [wCurEnemyLVL]
+	ld c, a
+	ld a, [wTempLevel]
+	ld b, a
+.level_loop
+	inc b
+	ld a, b
+	ld [wCurEnemyLVL], a
+	push bc
 	predef LearnMoveFromLevelUp
+	pop bc
+	ld a, b
+	cp c
+	jr nz, .level_loop
 	ld hl, wCanEvolveFlags
 	ld a, [wWhichPokemon]
 	ld c, a

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -2942,9 +2942,11 @@ IsNextTileShoreOrWater:
 	call IsInArray
 	jr nc, .notShoreOrWater
 	ld a, [wCurMapTileset]
-	cp SHIP_PORT ; Vermilion Dock tileset
+	ld hl, NonShoreTilesets
+	ld de, 1
+	call IsInArray ; check if shore tiles should be skipped
 	ld a, [wTileInFrontOfPlayer] ; tile in front of player
-	jr z, .skipShoreTiles ; if it's the Vermilion Dock tileset
+	jr c, .skipShoreTiles ; if it's the Vermilion Dock tileset
 	cp $48 ; eastern shore tile in Safari Zone
 	jr z, .shoreOrWater
 	cp $32 ; usual eastern shore tile

--- a/engine/menus/main_menu.asm
+++ b/engine/menus/main_menu.asm
@@ -681,7 +681,7 @@ SetCursorPositionsFromOptions:
 ; 00: X coordinate of menu cursor
 ; 01: delay after printing a letter (in frames)
 TextSpeedOptionData:
-	db 14, TEXT_DELAY_SLOW
+	db 15, TEXT_DELAY_SLOW
 	db  9, TEXT_DELAY_MEDIUM
 	db  1, TEXT_DELAY_FAST
 	db  9, -1 ; end (default X coordinate)

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -25,6 +25,8 @@ LoadSAV:
 	ld a, $1 ; bad checksum
 .goodsum
 	ld [wSaveFileStatus], a
+	ld a, 1
+	ld [wOptionsInitialized], a
 	ret
 
 FileDataDestroyedText:

--- a/engine/movie/oak_speech/init_player_data.asm
+++ b/engine/movie/oak_speech/init_player_data.asm
@@ -35,8 +35,6 @@ DEF START_MONEY EQU $3000
 	ld hl, wObtainedBadges
 	ld [hli], a
 
-	ld [hl], a
-
 	ld hl, wPlayerCoins
 	ld [hli], a
 	ld [hl], a

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -203,6 +203,7 @@ ENDU
 SECTION "Overworld Map", WRAM0
 
 UNION
+wTempLevel::
 wOverworldMap:: ds 1300
 wOverworldMapEnd::
 


### PR DESCRIPTION
These commits do the following:

- Port the level up code from Red++, so that levelling up multiple times in one go won't skip learning moves

- Fix Oak's speech not respecting text speed settings

- Fix MED text speed not being selectable

- Fix being able to fish in statues in gyms