### PR TITLE
fix strength cry

### DIFF
--- a/engine/menus/start_sub_menus.asm
+++ b/engine/menus/start_sub_menus.asm
@@ -177,6 +177,18 @@ StartMenu_Pokemon::
 .strength
 	bit BIT_RAINBOWBADGE, a
 	jp z, .newBadgeRequired
+	ld a, [wWhichPokemon]
+	ld hl, wPartySpecies
+	; bumping hl by a, need to make sure carry happens
+	ld c, a
+	ld a, l
+	add a, c
+	ld l, a
+	jr nc, .strengthNoCarry
+	inc h
+.strengthNoCarry
+	ld a, [hl]
+	ld [wcf91], a
 	predef PrintStrengthTxt
 	call GBPalWhiteOutWithDelay3
 	jp .goBackToMap

--- a/home/overworld_text.asm
+++ b/home/overworld_text.asm
@@ -30,6 +30,17 @@ BoulderText::
 	pop af 
 	ld [wWhichPokemon], a 
 	call GetPartyMonName2 
+	ld a, [wWhichPokemon]
+	ld hl, wPartySpecies
+	ld c, a
+	ld a, l
+	add a, c
+	ld l, a
+	jr nc, .noCarry
+	inc h
+.noCarry
+	ld a, [hl]
+	ld [wcf91], a
 	predef PrintStrengthTxt
 .done 
     jp TextScriptEnd 


### PR DESCRIPTION
The pokemon cry played when using strength is taken from the species at `wcf91` (it is played during the `PrintStrengthTxt` sub).

Both the menu entry for strength, and the interaction with an overworld boulder were not setting this variable.

To fix, we take the value of `wWhichPokemon` to get the party slot of the mon using strength, and add it to `wPartySpecies` to get the species value, which we then save to `wcf91` before calling `PrintStrengthTxt`.

We take care to deal with a potential carry in bumping the `l` register.