### PR TITLE
Bugfixes from ViWall's list

### DIFF
--- a/data/tilesets/pair_collision_tile_ids.asm
+++ b/data/tilesets/pair_collision_tile_ids.asm
@@ -21,4 +21,6 @@ TilePairCollisionsWater::
 	db FOREST, $14, $2E
 	db FOREST, $48, $2E
 	db CAVERN, $14, $05
+	db GYM	 , $14, $32	;prevent surfing into statue base tile ($32) from water tile ($14)
+	db GYM	 , $14, $33 ;prevent surfing into statue base tile ($33) from water tile ($14)
 	db -1 ; end

--- a/data/tilesets/warp_tile_ids.asm
+++ b/data/tilesets/warp_tile_ids.asm
@@ -1,3 +1,5 @@
+;Note: These warp tiles act like teleporters, initiating the warp when the player steps over them.
+;		Used for things like house entrances, cave entrances, etc.
 WarpTileIDPointers:
 	table_width 2, WarpTileIDPointers
 	dw .OverworldWarpTileIDs
@@ -103,16 +105,16 @@ ENDM
 	warp_tiles $1B, $1C, $0B, $0C, $58, $59
 
 .CelesteWarpTileIDs:
-	warp_tiles $5A, $5C, $3A, $30, $50, $51 ; Like Forest but a bit better
+	warp_tiles $5A, $5C, $3A	; Like Forest but a bit better
 
 .RocketHouseWarpTileIDs:
-	warp_tiles $53
+	warp_tiles
 
 .BetaMartWarpTileIDs:
-	warp_tiles $1C, $1D, $1E, $1F, $0C, $0D, $0E, $0F, $4B, $4C
+	warp_tiles $1C, $1D, $1E, $1F, $0C, $0D, $0E, $0F, $4B
 
 .JackyWarpTileIDs:
-	warp_tiles $04, $14
+	warp_tiles
 
 .ShipPortWarpTileIDs:
 .ClubWarpTileIDs:

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -131,7 +131,6 @@ ItemUseLetter:
 	ld a, [wIsInBattle]
 	and a
 	jp nz, ItemUseNotTime
-	text_asm
 	ld hl, ChiefLetterText
 	call PrintText
 	jp TextScriptEnd


### PR DESCRIPTION
Fixes the following issues
- You can Surf on large Pokemon statue tile
- Silph Letter displaying a bunch of random sounds when used
- The floor tiles for the exits of celeste hill, rocket house, jacky's house, and citrine mart will warp the player as soon as they were walked onto.