### PR TITLE
Fix volcano softlock and TMHM learning crash

### DIFF
--- a/home/names.asm
+++ b/home/names.asm
@@ -29,6 +29,14 @@ GetItemName::
 ;     starting at wcd6d
 	push hl
 	push bc
+	
+	;If you are going to make GetName check for wNameListType=ITEM_NAME, 
+	;then you have to make sure wNameListType get the proper value here. 
+	;Otherwise the game can crash when trying to learn TMHM items one after the other.
+	;Specifically if only TMHM items are in the current list view. - jojo
+	ld a, ITEM_NAME
+	ld [wNameListType], a
+	
 	ld a, [wd11e]
 	cp HM01 ; is this a TM/HM?
 	jr nc, .Machine

--- a/maps/CinnabarVolcano.blk
+++ b/maps/CinnabarVolcano.blk
@@ -1,1 +1,1 @@
-..............}vvvvvvvvvvvv}Qvvvvvvvvv}vvvvvvvvvvvvvvv45vvvvvvvv+,vvvv8-888vvNvvvvv	vvvvR}vvvv	vvv}N}vvv>vv}}}}Q}}}}}}QN
+..............}vvvvvvvvvvvv}Qvvvvvvvvv}vvvvvvvvvvvvvvv45vvvvvvvv+,vvvv8-588vvNvvvvv	vvvvR}vvvv	vvv}N}vvv>vv}}}}Q}}}}}}QN

--- a/maps/CinnabarVolcano.blk
+++ b/maps/CinnabarVolcano.blk
@@ -1,1 +1,1 @@
-..............}vvvvvvvvvvvv}Qvvvvvvvvv}vvvvvvvvvvvvvvv45vvvvvvvv+,,vvvv8-588vvNvvvvv	vvvvR}vvvv	vvv}N}vvv>vv}}}}Q}}}}}}QN
+..............}vvvvvvvvvvvv}Qvvvvvvvvv}vvvvvvvvvvvvvvv45vvvvvvvv+7,vvvv8-588vvNvvvvv	vvvvR}vvvv	vvv}N}vvv>vv}}}}Q}}}}}}QN

--- a/maps/CinnabarVolcano.blk
+++ b/maps/CinnabarVolcano.blk
@@ -1,1 +1,1 @@
-..............}vvvvvvvvvvvv}Qvvvvvvvvv}vvvvvvvvvvvvvvv45vvvvvvvv+,vvvv8-588vvNvvvvv	vvvvR}vvvv	vvv}N}vvv>vv}}}}Q}}}}}}QN
+..............}vvvvvvvvvvvv}Qvvvvvvvvv}vvvvvvvvvvvvvvv45vvvvvvvv+,,vvvv8-588vvNvvvvv	vvvvR}vvvv	vvv}N}vvv>vv}}}}Q}}}}}}QN


### PR DESCRIPTION
**1. Changes two tile blocks in the volcano. Makes it so the path back cannot be blocked.**

![image](https://github.com/PlagueVonKarma/kep-hack/assets/47074297/159da02d-3176-4537-93ab-9f85c6b14a93)
![image](https://github.com/PlagueVonKarma/kep-hack/assets/47074297/b59467d3-42a1-415a-9fcb-31fe1e25fc5b)

**2. Fixed the crash that can happen when learning two TMs one after the other.**

[TMHM crash explanation.txt](https://github.com/PlagueVonKarma/kep-hack/files/13856951/TMHM.crash.explanation.txt)

