### PR TITLE
Fix Text Issues in Silph Gauntlet

### DIFF
--- a/text/SilphGauntlet2F.asm
+++ b/text/SilphGauntlet2F.asm
@@ -75,8 +75,8 @@ _SilphGauntlet2FAfterBattleText4::
 	
 	para "I could never have"
 	line "expected to see"
-	cont "#MON like yours,"
-	cont "though!"
+	cont "#MON like"
+	cont "yours, though!"
 	done
 
 _SilphGauntlet2FBattleText5::

--- a/text/SilphGauntlet3F.asm
+++ b/text/SilphGauntlet3F.asm
@@ -95,7 +95,7 @@ _SilphGauntlet3FAfterBattleText5::
 	line "here stinks!"
 	
 	para "Where's all the"
-	cont "rock 'n' roll?!"
+	line "rock 'n' roll?!"
 	done
 
 _SilphGauntlet3FBattleText6::

--- a/text/SilphGauntlet5F.asm
+++ b/text/SilphGauntlet5F.asm
@@ -87,7 +87,7 @@ _SilphGauntlet5FAfterBattleText5::
 	text "Huh? Yeah! We"
 	line "used our whips!"
 	
-	para "...hey, what's"
+	para "...Hey, what's"
 	line "with that stare?"
 	done
 

--- a/text/SilphGauntlet7F.asm
+++ b/text/SilphGauntlet7F.asm
@@ -13,7 +13,7 @@ _ChiefMonologue::
 	prompt
 
 _ChiefMonologueMasterBallNotUsed::
-	text "You're looking for"
+	text "You're looking"
 	line "for the ultimate"
 	cont "#MON, aren't"
 	cont "you?"
@@ -38,7 +38,7 @@ _ChiefMonologueMasterBallNotUsed::
 	done
 
 _ChiefMonologueMasterBallUsed::
-	text "You're looking for"
+	text "You're looking"
 	line "for the ultimate"
 	cont "#MON, aren't"
 	cont "you?"
@@ -52,7 +52,7 @@ _ChiefMonologueMasterBallUsed::
 	cont "our company is"
 	cont "going under!"
 
-	para "...what? You used"
+	para "...What? You used"
 	line "the MASTER BALL?!"
 	
 	para "You stupid child!"
@@ -93,8 +93,8 @@ _ChiefMonologueMasterBallNotCollected::
 	done
 
 _ChiefDefeatedText::
-	text "No! I..."
-	line "I..."
+	text "No!"
+	line "I... I..."
 	prompt
 
 _ChiefVictoryText::
@@ -144,7 +144,7 @@ _ChiefAltAfterBattleText::
 	line "be as powerful as"
 	cont "I want, but what"
 	cont "I do with that"
-	cont "power...is very"
+	cont "power... is very"
 	cont "important."
 	
 	para "I still have much"


### PR DESCRIPTION
The 4th trainer's after battle text in Silph Gauntlet 2F has one of its lines cut off due to the scroll arrow and that same line overflows the textbox.

The Rocker in one of the rooms in the 3F Silph Gauntlet had an erroneous line break in his after battle text.

In one of the trainer's after battle texts in Silph Gauntlet 5F, they start a sentence without capitalizing it. In this case, since it starts a new sentence, the word after the ellipsis needs to be capitalized.

Removed a duplicate "for" in both of the Silph Chief's before battle texts. Additionally, in his loss text, moved the "I... I..." all to one line for the aesthetics.