### PR TITLE
attempt to band-aide missable objects not hiding properly

### DIFF
--- a/engine/overworld/missable_objects.asm
+++ b/engine/overworld/missable_objects.asm
@@ -142,8 +142,21 @@ HideObject:
 	ld c, a
 	ld b, FLAG_SET
 	call MissableObjectFlagAction   ; set "removed" flag
+	call VerifyObjectState
+	jr z, HideObject
 	jp UpdateSprites
 
+;returns z flag set if shown and z flag cleared if hidden
+VerifyObjectState:
+	ld hl, wMissableObjectFlags
+	ld a, [wMissableObjectIndex]
+	ld c, a
+	ld b, FLAG_TEST
+	call MissableObjectFlagAction  
+	ld a, c
+	and a
+	ret
+	
 MissableObjectFlagAction:
 ; identical to FlagAction
 


### PR DESCRIPTION
For some unknown reason, sometimes a missable object will run through its script to be hidden but its associated flag in wMissableObjectFlags will not be set. This is a band-aide fix that makes HideObject loop until the flag for the value in wMissableObjectIndex is verified to have been set.

One of three things is going to happen.
1. This will fix the problem and it can be put out of mind.
2. This will do nothing, meaning that wMissableObjectIndex  is somehow holding the wrong value.
3. The flag just will just not set so an infinite loop is created (experienced as a game freeze with music continuing). Highly unlikely that this happens because it would mean that wMissableObjectFlags is non-writable.