### PR TITLE
band-aid fix for the border block glitch

### DIFF
--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -2087,7 +2087,12 @@ LoadMapHeader::
 	ld [wCurMapTileset], a
 	ldh [hPreviousTileset], a
 	bit 7, b
-	ret nz
+
+	;replace the conditional return with a nop in order to always load the map header data...
+	;...even when selecting CONTINUE from the main menu
+;	ret nz
+	nop
+
 	ld hl, MapHeaderPointers
 	ld a, [wCurMap]
 	sla a


### PR DESCRIPTION
If you look through the LoadSAV0 function, you'll notice that it sets bit 7 of wCurMapTileset when the game loads. Why does it do this?

You see, all the current map data is included as part of the save. That means it gets copied into all the right places in wram when the save file loads. When you go from the main title menu and actually enter the map, the game is doing it using the same code as special map entry warp (like when you go through a door). These kinds of warps load all the map data as you would expect.

But wait, didn't I just say that the act of loading the save file already loads the map data? That means it would needlessly get loaded twice! Apparently Gamefreak thought the same thing. 

Remember how bit 7of wCurMapTileset is set when the game loads? The function LoadMapHeader actually checks for that bit and clears it. If that bit was detected as set, then the function knows that it is being run upon selecting CONTINUE from the main menu. If so, it skips loading all the map data since it has already been loaded. 

This check can be bypassed to make the map header data always load upon continuing the game. Doing so will force the border block to refresh to the correct value.

Changing ret nz here to nop is a change of 1 byte in rom with no shifting of addresses, thus preserving the ability to keep using the same save file.

