### PR TITLE
Improved border block glitch fix and Cat vs Dog Beauty Fixes

### DIFF
--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -2082,17 +2082,12 @@ LoadMapHeader::
 	ld a, [wCurMap]
 	call SwitchToMapRomBank
 	ld a, [wCurMapTileset]
-	ld b, a
+	bit 7, a
 	res 7, a
 	ld [wCurMapTileset], a
 	ldh [hPreviousTileset], a
-	bit 7, b
-
-	;replace the conditional return with a nop in order to always load the map header data...
-	;...even when selecting CONTINUE from the main menu
-;	ret nz
-	nop
-
+;	ret nz		;comment this out so that the header data always loads
+	push af		;preserve the bit check for later to tell if CONTINUE is being selected
 	ld hl, MapHeaderPointers
 	ld a, [wCurMap]
 	sla a
@@ -2150,7 +2145,7 @@ LoadMapHeader::
 	ld [wObjectDataPointerTemp], a
 	ld a, [hli]
 	ld [wObjectDataPointerTemp + 1], a
-	push hl
+;	push hl	; save hl before going to the warp/sign/sprite data (this value is saved for seemingly no purpose)
 	ld a, [wObjectDataPointerTemp]
 	ld l, a
 	ld a, [wObjectDataPointerTemp + 1]
@@ -2158,6 +2153,9 @@ LoadMapHeader::
 	ld de, wMapBackgroundTile
 	ld a, [hli]
 	ld [de], a
+	pop af		;we're done if loading from the CONTINUE option of the main menu
+	ret nz
+	nop	;padding
 .loadWarpData
 	ld a, [hli]
 	ld [wNumberOfWarps], a
@@ -2330,7 +2328,7 @@ LoadMapHeader::
 .finishUp
 	predef LoadTilesetHeader
 	callfar LoadWildData
-	pop hl ; restore hl from before going to the warp/sign/sprite data (this value was saved for seemingly no purpose)
+;	pop hl ; restore hl from before going to the warp/sign/sprite data (this value was saved for seemingly no purpose)
 	ld a, [wCurMapHeight] ; map height in 4x4 tile blocks
 	add a ; double it
 	ld [wCurrentMapHeight2], a ; store map height in 2x2 tile blocks

--- a/scripts/SilphCo7F.asm
+++ b/scripts/SilphCo7F.asm
@@ -309,8 +309,8 @@ SilphCo7TrainerHeader3:
 SilphCo7Text1:
 ; lapras guy
 	text_asm
-	ld a, [wd72c]
-	bit 2, a
+	ld a, [wd72e]
+	bit 0, a
 	jr z, .givelapras
 	CheckEvent EVENT_BEAT_SILPH_CO_GIOVANNI
 	jr nz, .savedsilph
@@ -329,8 +329,8 @@ SilphCo7Text1:
 	call EnableAutoTextBoxDrawing
 	ld hl, .HeresYourLaprasText
 	call PrintText
-	ld hl, wd72c
-	set 2, [hl]
+	ld hl, wd72e
+	set 0, [hl]
 	jr .done
 .savedsilph
 	ld hl, .LaprasGuySavedText

--- a/text/VermilionCity.asm
+++ b/text/VermilionCity.asm
@@ -136,7 +136,7 @@ _BeautyText2::
 	prompt ; needed for text to scroll correctly - it looks and acts fine in-game, don't worry.
 
 _BeautyChoice:: ; this is separate for the in-progress event.
-	text "If you catch 5"
+	text "If you catch 5 new"
 	line "@"
 	text_ram wcd6d ; efficiency - means we don't need two separate texts...
 	text ", I'll"


### PR DESCRIPTION
This improvement to the border block fix will prevent the player's location from being reset in interior areas.

The Cat vs Dog Beauty quest line has the following fixes:
- Fixed potential weirdness with the SilphCo Lapras gift event bit by reverting it back to vanilla. The CatDog quest does not need bit 0 of wd72e anymore.
- Text clarifies to catch 5 "new" growlithe/meowth.
- Fixed an issue where exactly 5 must be caught which causes a problem if wBeautyCounter is ever > 5.
- Fixed a text box reloading from tile buffer (buffering is not needed anymore).
- Pressing B at the question box will back out of giving an answer.