### PR TITLE
Bug Fix: Incorrect Type displays

### DIFF
--- a/data/types/names.asm
+++ b/data/types/names.asm
@@ -3,7 +3,6 @@ TypeNames:
 
 	dw .Normal
 	dw .Fighting
-	dw .Flying
 	dw .Poison
 	dw .Ground
 	dw .Rock
@@ -16,6 +15,7 @@ REPT UNUSED_TYPES_END - UNUSED_TYPES
 	dw .Normal
 ENDR
 
+	dw .Flying
 	dw .Fire
 	dw .Water
 	dw .Grass

--- a/data/types/type_matchups.asm
+++ b/data/types/type_matchups.asm
@@ -34,7 +34,7 @@ TypeEffects:
 	db WATER,        GROUND,       SUPER_EFFECTIVE
 	db ELECTRIC,     GROUND,       NO_EFFECT
 	db ELECTRIC,     FLYING,       SUPER_EFFECTIVE
-	db ELECTRIC,     BIRD,         NOT_VERY_EFFECTIVE
+	db ELECTRIC,     BIRD,         SUPER_EFFECTIVE
 	db GRASS,        GROUND,       SUPER_EFFECTIVE
 	db GRASS,        BUG,          NOT_VERY_EFFECTIVE
 	db GRASS,        POISON,       NOT_VERY_EFFECTIVE


### PR DESCRIPTION
## Includes the following:

- Moving the Flying type name in the names table down with the other special types.
- Making Bird weak to Electric as the README describes.
___

## Explanation of commit 1:

Due to the change to make Flying a special type, the values in [type_constants.asm](https://github.com/ShiraTheMogul/kep-hack/blob/the-kepiversary/constants/type_constants.asm) between Poison and Steel are all decremented by 1, as well as the values UNUSED_TYPES and UNUSED_TYPES_END, with Flying filling the gap before the other special types. Because the name table uses these values to similarly space the type names, a bug surfaced where all of the physical types (aside from normal/fighting) and flying appeared as other types in the Pokemon status pages and Pokedex entries. Incorrect types were as follows (actual type -> name shown):

- Steel -> Ghost
- Ghost -> Bug
- Bug -> Bird
- Bird -> Rock
- Rock -> Ground
- Ground -> Poison
- Poison -> Flying
- Flying -> Normal

By moving .flying in the name table, the alignment is restored.
___

## Pictures:

#### Bug active:
<img width="767" height="638" alt="Pidgeotto_Wrong" src="https://github.com/user-attachments/assets/21b83b74-1cbb-4a38-a942-f88a1d21e17e" />

<img width="768" height="640" alt="Perrserker_Ghost" src="https://github.com/user-attachments/assets/c9abbca4-8d20-482e-b213-38dd50c0c5d5" />

<img width="769" height="635" alt="Nidoreign_Wrong" src="https://github.com/user-attachments/assets/9a68e115-6968-44af-9d18-a209eee2289d" />

#### Bug squashed:
<img width="768" height="638" alt="Pidgeotto_Right" src="https://github.com/user-attachments/assets/98d2a691-8484-4143-9ba4-dc75244489f2" />

<img width="767" height="637" alt="Perrserker_Right" src="https://github.com/user-attachments/assets/06f5c45f-eda9-4f3d-8534-6310651d67c0" />

<img width="767" height="637" alt="Nidoreign_Right" src="https://github.com/user-attachments/assets/8f167fe0-07d8-425a-babd-fedea1465c56" />